### PR TITLE
Make Command extend from NSObject

### DIFF
--- a/SwiftCLI/Commands/Command.swift
+++ b/SwiftCLI/Commands/Command.swift
@@ -20,7 +20,7 @@ enum CommandResult {
     case Failure(String)
 }
 
-class Command {
+class Command: NSObject {
     
     var arguments: NSDictionary = [:]
     var options: Options = Options()


### PR DESCRIPTION
I was using `Command` in a project of mine (https://github.com/victor/whereami) and wanted a `Command` to be also a delegate for `CLLocationManager`, but the compiler complained that it was not implementing `NSObjectProtocol`, which `CLLocationManagerDelegate` declares as extending.

I found that the simplest way was to make `Command` not be a root class, but an `NSObject` instead, so that commands can implement a variety of standard framework delegates. And hence this pull request, to make SwiftCLI more useful (IMHO, of course)
