### PR TITLE
respect version number in CLI.setup()

### DIFF
--- a/SwiftCLI/CLI/CLI.swift
+++ b/SwiftCLI/CLI/CLI.swift
@@ -19,7 +19,7 @@ public class CLI: NSObject {
         
         static var commands: [Command] = []
         static var helpCommand: HelpCommand? = HelpCommand()
-        static var versionComand: VersionCommand? = VersionCommand()
+        static var versionCommand: VersionCommand? = VersionCommand()
         static var defaultCommand: Command = CLIStatic.helpCommand!
     }
     
@@ -62,7 +62,7 @@ public class CLI: NSObject {
     }
     
     public class func registerCustomVersionCommand(versionCommand: VersionCommand?) {
-        CLIStatic.versionComand = versionCommand
+        CLIStatic.versionCommand = versionCommand
     }
     
     public class func registerDefaultCommand(command: Command) {
@@ -110,7 +110,7 @@ public class CLI: NSObject {
             hc.allCommands = CLIStatic.commands
             allCommands.append(hc)
         }
-        if let vc = CLIStatic.versionComand {
+        if let vc = CLIStatic.versionCommand {
             allCommands.append(vc)
         }
         

--- a/SwiftCLI/CLI/CLI.swift
+++ b/SwiftCLI/CLI/CLI.swift
@@ -23,10 +23,10 @@ public class CLI: NSObject {
         static var defaultCommand: Command = CLIStatic.helpCommand!
     }
     
-    public class func setup(#name: String, version: String = "1.0", description: String = "") {
+    public class func setup(#name: String, version: String? = nil, description: String? = nil) {
         CLIStatic.appName = name
-        CLIStatic.appVersion = version
-        CLIStatic.appDescription = description
+        if let v = version     { CLIStatic.appVersion = v }
+        if let d = description { CLIStatic.appDescription = d }
     }
     
     public class func appName() -> String {
@@ -35,6 +35,10 @@ public class CLI: NSObject {
     
     public class func appDescription() -> String {
         return CLIStatic.appDescription
+    }
+
+    public class func appVersion() -> String {
+        return CLIStatic.appVersion
     }
     
     // MARK: - Registering commands

--- a/SwiftCLI/Commands/Special/VersionCommand.swift
+++ b/SwiftCLI/Commands/Special/VersionCommand.swift
@@ -10,8 +10,6 @@ import Foundation
 
 public class VersionCommand: Command {
     
-    var version = "1.0"
-    
     override public func commandName() -> String  {
         return "version"
     }
@@ -25,7 +23,7 @@ public class VersionCommand: Command {
     }
     
     override public func execute() -> ExecutionResult  {
-        println("Version: \(version)")
+        println("Version: \(CLI.appVersion())")
         
         return success()
     }


### PR DESCRIPTION
prior to this the VersionCommand seems to have always returned “1.0” no matter what the user passed as `version:` in the `setup()` method.