### PR TITLE
Updated code to make it work with Swift 3.0 PREVIEW 6 on Ubuntu

### DIFF
--- a/Sources/CommandSignature.swift
+++ b/Sources/CommandSignature.swift
@@ -17,8 +17,8 @@ class CommandSignature {
     init(_ string: String) {
         let parameters = string.components(separatedBy: " ").filter { !$0.isEmpty }
         
-        let requiredRegex = try! NSRegularExpression(pattern: "^<.*>$", options: [])
-        let optionalRegex = try! NSRegularExpression(pattern: "^\\[<.*>\\]$", options: [])
+        let requiredRegex = try! RegularExpression(pattern: "^<.*>$", options: [])
+        let optionalRegex = try! RegularExpression(pattern: "^\\[<.*>\\]$", options: [])
         
         for parameter in parameters {
             if parameter == "..." {

--- a/Sources/Input.swift
+++ b/Sources/Input.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class Input {
     
-    private static let inputHandle = FileHandle.standardInput
+    private static let inputHandle = FileHandle.standardInput()
     
     public private(set) static var pipedData: String? = nil
     
@@ -99,10 +99,10 @@ public class Input {
     // MARK: - Internal
     
     class func checkForPipedData() {
-        inputHandle.readabilityHandler = {(inputHandle) in
-            pipedData = String(data: inputHandle.availableData, encoding: String.Encoding.utf8)
-            inputHandle.readabilityHandler = nil
-        }
+//        inputHandle.readabilityHandler = {(inputHandle) in
+//            pipedData = String(data: inputHandle.availableData, encoding: String.Encoding.utf8)
+//            inputHandle.readabilityHandler = nil
+//        }
         let _ = ProcessInfo.processInfo.arguments // For whatever reason, this triggers readabilityHandler for the pipe data
     }
     

--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -13,7 +13,7 @@ func printError(_ error: String) {
 }
 
 func printError(_ error: String, terminator: String) {
-    let handle = FileHandle.standardError
+    let handle = FileHandle.standardError()
     let fullString = error + terminator
     if let errorData = fullString.data(using: String.Encoding.utf8, allowLossyConversion: false) {
         handle.write(errorData)

--- a/Sources/RawArguments.swift
+++ b/Sources/RawArguments.swift
@@ -22,11 +22,11 @@ public class RawArguments: CustomStringConvertible {
     private var argumentClassifications: [RawArgumentType] = []
     
     convenience init() {
-        self.init(arguments: ProcessInfo.processInfo.arguments)
+        self.init(arguments: ProcessInfo.processInfo().arguments)
     }
     
     convenience init(argumentString: String) {
-        let regex = try! NSRegularExpression(pattern: "(\"[^\"]*\")|[^\"\\s]+", options: [])
+        let regex = try! RegularExpression(pattern: "(\"[^\"]*\")|[^\"\\s]+", options: [])
         
         let argumentMatches = regex.matches(in: argumentString, options: [], range: NSRange(location: 0, length: argumentString.utf8.count))
         


### PR DESCRIPTION
These updates make SwiftCLI "compileable" with Swift 3.0 PREVIEW 6 on my Ubuntu installation resolving #18.

Just followed compilation errors and Foundation library docs to remove issues.

BTW You need to check class function checkForPipedData() in Input.swift as I wasn't sure how to solve the issue, so I just commented out problematic lines. Can be Swift guys corrected behavior you were trying to solve with this function and now it works OK.

Feel free to comment.

BTW Thanks a lot for SwiftCLI, it's making creating my app much more easier. 