### PR TITLE
Linux build and test compliance changes

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -249,3 +249,13 @@ extension CLIResult {
     }
     
 }
+
+// MARK: - Compatibility
+
+#if os(Linux)
+typealias Regex = RegularExpression
+
+#else
+typealias Regex = NSRegularExpression
+
+#endif

--- a/Sources/CommandSignature.swift
+++ b/Sources/CommandSignature.swift
@@ -17,8 +17,8 @@ public class CommandSignature {
     init(_ string: String) {
         let parameters = string.components(separatedBy: " ").filter { !$0.isEmpty }
         
-        let requiredRegex = try! NSRegularExpression(pattern: "^<.*>$", options: [])
-        let optionalRegex = try! NSRegularExpression(pattern: "^\\[<.*>\\]$", options: [])
+        let requiredRegex = try! Regex(pattern: "^<.*>$", options: [])
+        let optionalRegex = try! Regex(pattern: "^\\[<.*>\\]$", options: [])
         
         for parameter in parameters {
             if parameter == "..." {

--- a/Sources/Input.swift
+++ b/Sources/Input.swift
@@ -93,11 +93,13 @@ public class Input {
     // MARK: - Internal
     
     static func checkForPipedData() {
+		#if !os(Linux) // Temporary until readabilityHandler is implemented in Swift Foundation
         inputHandle.readabilityHandler = {(inputHandle) in
             pipedData = String(data: inputHandle.availableData, encoding: String.Encoding.utf8)
             inputHandle.readabilityHandler = nil
         }
         let _ = ProcessInfo.processInfo.arguments // For whatever reason, this triggers readabilityHandler for the pipe data
+		#endif
     }
     
 }

--- a/Sources/RawArguments.swift
+++ b/Sources/RawArguments.swift
@@ -47,7 +47,7 @@ public class RawArguments {
     }
     
     convenience init(argumentString: String) {
-        let regex = try! NSRegularExpression(pattern: "(\"[^\"]*\")|[^\"\\s]+", options: [])
+        let regex = try! Regex(pattern: "(\"[^\"]*\")|[^\"\\s]+", options: [])
         
         let argumentMatches = regex.matches(in: argumentString, options: [], range: NSRange(location: 0, length: argumentString.utf8.count))
         

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import SwiftCLITests
+
+XCTMain([
+     testCase(SwiftCLITests.allTests),
+])

--- a/Tests/SwiftCLITests/SwiftCLITests.swift
+++ b/Tests/SwiftCLITests/SwiftCLITests.swift
@@ -46,5 +46,12 @@ class SwiftCLITests: XCTestCase {
         
         executionString = ""
     }
+
+    static var allTests : [(String, (SwiftCLITests) -> () throws -> Void)] {
+        return [
+            ("testCLIGo", testCLIGo),
+            ("testCLIHelp", testCLIHelp)
+        ]
+    }
     
 }


### PR DESCRIPTION
Tested with Swift 3.0 RELEASE, Swift 3.0.1 PREVIEW 3 on Ubuntu 16.04

I believe that class RegularExpression is on Mac as well (it should be per Swift Foundation Library 3.0), so we could ditch NSRegularExpression on Mac and use pure Swift RegularExpression class. But that's up to you @jakeheis

BTW Good job on SwiftCLI 2.0!