### PR TITLE
Adding import to first README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A powerful framework that can be used to develop a CLI, from the simplest to the
 //
 
 import Foundation
+import SwiftCLI
 
 CLI.setup(name: "greeter")
 CLI.registerChainableCommand(name: "greet")


### PR DESCRIPTION
I believe it's missing `import SwiftCLI`, isn't it?