### PR TITLE
Returning back to NSRegularExpression for all platforms

### DIFF
--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -266,10 +266,10 @@ extension CLIResult {
 
 // MARK: - Compatibility
 
-#if os(Linux)
-typealias Regex = RegularExpression
+//#if os(Linux)
+//typealias Regex = RegularExpression
 
-#else
+//#else
 typealias Regex = NSRegularExpression
 
-#endif
+//#endif


### PR DESCRIPTION
With latest Swift development snapshots it seems they have decided to go back to `NSRegularExpression` class for all platforms. Hopefully Swift devs made their minds with all this naming nonsense.

For now I have decided just to "comment it out", in future it might be removed and just the line `typealias Regex = NSRegularExpression` left there.

I guess they will make it official with Swift 3.1 release, so please keep this PR open until 3.1 is released then merge it and tag it.

Thanks.