### PR TITLE
Fix collecting parameters and options for inherited commands

### DIFF
--- a/Tests/SwiftCLITests/Fixtures.swift
+++ b/Tests/SwiftCLITests/Fixtures.swift
@@ -42,6 +42,10 @@ class TestCommand: Command {
 
 }
 
+class TestInheritedCommand: TestCommand {
+    let verbose = Flag("-v", "--verbose", description: "Show more output information")
+}
+
 // MARK: -
 
 let alphaCmd = AlphaCmd()
@@ -98,6 +102,10 @@ class Req2Cmd: EmptyCmd {
 class Opt2Cmd: EmptyCmd {
     let opt1 = OptionalParameter()
     let opt2 = OptionalParameter()
+}
+
+class Opt2InhCmd: Opt2Cmd {
+    let opt3 = OptionalParameter()
 }
 
 class ReqCollectedCmd: EmptyCmd {

--- a/Tests/SwiftCLITests/HelpMessageGeneratorTests.swift
+++ b/Tests/SwiftCLITests/HelpMessageGeneratorTests.swift
@@ -79,6 +79,25 @@ class HelpMessageGeneratorTests: XCTestCase {
         XCTAssertEqual(message, expectedMessage, "Should generate the correct usage statement")
     }
     
+    func testInheritedUsageStatementGeneration() {
+        let cli = CLI(name: "tester")
+        let message = DefaultHelpMessageGenerator().generateUsageStatement(for: TestInheritedCommand(), in: cli)
+        
+        let expectedMessage = """
+        
+        Usage: tester test <testName> [<testerName>] [options]
+        
+        Options:
+          -h, --help             Show help information for this command
+          -s, --silent           Silence all test output
+          -t, --times <value>    Number of times to run the test
+          -v, --verbose          Show more output information
+        
+        """
+        
+        XCTAssertEqual(message, expectedMessage, "Should generate the correct usage statement")
+    }
+    
     func testMisusedOptionsStatementGeneration() {
         let arguments = ArgumentList(argumentString: "tester test -s -a --times")
         arguments.remove(node: arguments.head!)

--- a/Tests/SwiftCLITests/ParameterFillerTests.swift
+++ b/Tests/SwiftCLITests/ParameterFillerTests.swift
@@ -29,6 +29,7 @@ class ParameterFillerTests: XCTestCase {
     private var req2: Req2Cmd { return current as! Req2Cmd }
     private var opt1: Opt1Cmd { return current as! Opt1Cmd }
     private var opt2: Opt2Cmd { return current as! Opt2Cmd }
+    private var opt2Inh: Opt2InhCmd { return current as! Opt2InhCmd }
     private var reqCollected: ReqCollectedCmd{ return current as! ReqCollectedCmd }
     private var optCollected: OptCollectedCmd { return current as! OptCollectedCmd }
     private var req2Collected: Req2CollectedCmd{ return current as! Req2CollectedCmd }
@@ -84,6 +85,32 @@ class ParameterFillerTests: XCTestCase {
         current = Opt2Cmd()
         arguments = ["arg1", "arg2", "arg3"]
         assertParseFails("Signature parser should fail for 2 optional arguments and 3 passed arguments")
+    }
+    
+    func testOptionalParametersWithInheritance() {
+        current = Opt2InhCmd()
+        arguments = []
+        assertParse(opt2Inh.opt1.value == nil && opt2Inh.opt2.value == nil,
+                    assertMessage: "Signature parser should succeed for 2 optional arguments and 0 passed arguments")
+        
+        current = Opt2InhCmd()
+        arguments = ["arg1"]
+        assertParse(opt2Inh.opt1.value == "arg1" && opt2Inh.opt2.value == nil,
+                    assertMessage: "Signature parser should succeed for 2 optional arguments and 1 passed argument")
+        
+        current = Opt2InhCmd()
+        arguments = ["arg1", "arg2"]
+        assertParse(opt2Inh.opt1.value == "arg1" && opt2Inh.opt2.value == "arg2",
+                    assertMessage: "Signature parser should succeed for 2 optional arguments and 2 passed arguments")
+        
+        current = Opt2InhCmd()
+        arguments = ["arg1", "arg2", "arg3"]
+        assertParse(opt2Inh.opt1.value == "arg1" && opt2Inh.opt2.value == "arg2" && opt2Inh.opt3.value == "arg3",
+                    assertMessage: "Signature parser should succeed for 3 optional arguments and 3 passed arguments")
+        
+        current = Opt2InhCmd()
+        arguments = ["arg1", "arg2", "arg3", "arg4"]
+        assertParseFails("Signature parser should fail for 3 optional arguments and 4 passed arguments")
     }
     
     func testExtraneousArguments() {


### PR DESCRIPTION
If I want to create some base command with specific options and inherit some commands from it then I got wrong help output with missed base options.

I fixed collecting parameters and options so they do it recursive now. Tests included :)