### PR TITLE
Remove deprecated use of String characters

### DIFF
--- a/Sources/SwiftCLI/ArgumentListManipulator.swift
+++ b/Sources/SwiftCLI/ArgumentListManipulator.swift
@@ -51,7 +51,7 @@ public class OptionSplitter: ArgumentListManipulator {
                 node.value = String(node.value[..<equalsIndex])
             } else if node.value.hasPrefix("-") && !node.value.hasPrefix("--") {
                 var previous = node
-                node.value.characters.dropFirst().forEach {
+                node.value.dropFirst().forEach {
                     previous = arguments.insert(value: "-\($0)", after: previous)
                 }
                 arguments.remove(node: node)

--- a/Sources/SwiftCLI/CompletionGenerator.swift
+++ b/Sources/SwiftCLI/CompletionGenerator.swift
@@ -102,7 +102,7 @@ public final class ZshCompletionGenerator: CompletionGenerator {
             let middle = "{" + option.names.joined(separator: ",") + "}"
             let end: String
             if option.shortDescription.isEmpty {
-                let sortedNames = option.names.sorted(by: {$0.characters.count > $1.characters.count})
+                let sortedNames = option.names.sorted(by: {$0.count > $1.count})
                 end = "[" + sortedNames.first!.trimmingCharacters(in: CharacterSet(charactersIn: "-")) + "]"
             } else {
                 end = "[" + option.shortDescription + "]"

--- a/Sources/SwiftCLI/HelpMessageGenerator.swift
+++ b/Sources/SwiftCLI/HelpMessageGenerator.swift
@@ -33,14 +33,14 @@ extension HelpMessageGenerator {
         }
         
         let maxNameLength = routables.reduce(12) { (length, routable) in
-            if routable.name.characters.count > length {
-               return routable.name.characters.count
+            if routable.name.count > length {
+               return routable.name.count
             }
             return length
         }
         
         func toLine(_ routable: Routable) -> String {
-            let spacing = String(repeating: " ", count: maxNameLength + 4 - routable.name.characters.count)
+            let spacing = String(repeating: " ", count: maxNameLength + 4 - routable.name.count)
             return "  \(routable.name)\(spacing)\(routable.shortDescription)"
         }
         
@@ -75,8 +75,8 @@ extension HelpMessageGenerator {
                 return lhs.names.first! < rhs.names.first!
             }
             let maxOptionLength = sortedOptions.reduce(12) { (length, option) in
-                if option.identifier.characters.count > length {
-                    return option.identifier.characters.count
+                if option.identifier.count > length {
+                    return option.identifier.count
                 }
                 return length
             }

--- a/Sources/SwiftCLI/Option.swift
+++ b/Sources/SwiftCLI/Option.swift
@@ -15,7 +15,7 @@ public protocol Option {
 
 public extension Option {
     func usage(padding: Int) -> String {
-        let spacing = String(repeating: " ", count: padding - identifier.characters.count)
+        let spacing = String(repeating: " ", count: padding - identifier.count)
         return "\(identifier)\(spacing)\(shortDescription)"
     }
 }


### PR DESCRIPTION
In Swift 4, Strings are a collection of Characters:
https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/StringsAndCharacters.html

Thanks for reviewing.