### PR TITLE
Fix error message for only required collected parameter

### DIFF
--- a/Sources/SwiftCLI/ParameterFiller.swift
+++ b/Sources/SwiftCLI/ParameterFiller.swift
@@ -62,14 +62,14 @@ public class DefaultParameterFiller: ParameterFiller {
     }
     
     func wrongArgCount(signature: CommandSignature, got: Int) -> CLI.Error {
-        let requiredCount = signature.required.count
+        var requiredCount = signature.required.count
+        if signature.collected?.required == true {
+            requiredCount += 1
+        }
         let optionalCount = signature.optional.count
         
         let plural = requiredCount == 1 ? "argument" : "arguments"
         if let collected = signature.collected {
-            if collected.required {
-                return CLI.Error(message: "error: command requires at least 1 argument, got 0")
-            }
             return CLI.Error(message: "error: command requires at least \(requiredCount) \(plural), got \(got)")
         }
         if optionalCount == 0 {

--- a/Sources/SwiftCLI/ParameterFiller.swift
+++ b/Sources/SwiftCLI/ParameterFiller.swift
@@ -66,7 +66,10 @@ public class DefaultParameterFiller: ParameterFiller {
         let optionalCount = signature.optional.count
         
         let plural = requiredCount == 1 ? "argument" : "arguments"
-        if signature.collected != nil {
+        if let collected = signature.collected {
+            if collected.required {
+                return CLI.Error(message: "error: command requires at least 1 argument, got 0")
+            }
             return CLI.Error(message: "error: command requires at least \(requiredCount) \(plural), got \(got)")
         }
         if optionalCount == 0 {

--- a/Tests/SwiftCLITests/ParameterFillerTests.swift
+++ b/Tests/SwiftCLITests/ParameterFillerTests.swift
@@ -213,7 +213,8 @@ class ParameterFillerTests: XCTestCase {
         XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 0).message, "error: command requires at least 1 argument, got 0")
 
         signature = CommandSignature(command: Req2CollectedCmd())
-        XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 0).message, "error: command requires at least 1 argument, got 0")
+        XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 0).message, "error: command requires at least 2 arguments, got 0")
+        XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 1).message, "error: command requires at least 2 arguments, got 1")
         
         signature = CommandSignature(command: Req2Opt2Cmd())
         XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 1).message, "error: command requires between 2 and 4 arguments, got 1")

--- a/Tests/SwiftCLITests/ParameterFillerTests.swift
+++ b/Tests/SwiftCLITests/ParameterFillerTests.swift
@@ -124,6 +124,10 @@ class ParameterFillerTests: XCTestCase {
     }
     
     func testCollectedRequiredParameters() {
+        current = ReqCollectedCmd()
+        arguments = []
+        assertParseFails("Signature parser should fail for 1 required argument and 0 passed arguments")
+
         current = Req2CollectedCmd()
         arguments = ["arg1"]
         assertParseFails("Signature parser should fail for 2 required argument and 1 passed arguments")
@@ -205,6 +209,9 @@ class ParameterFillerTests: XCTestCase {
         XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 1).message, "error: command requires exactly 2 arguments, got 1")
         XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 3).message, "error: command requires exactly 2 arguments, got 3")
         
+        signature = CommandSignature(command: ReqCollectedCmd())
+        XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 0).message, "error: command requires at least 1 argument, got 0")
+
         signature = CommandSignature(command: Req2CollectedCmd())
         XCTAssertEqual(filler.wrongArgCount(signature: signature, got: 0).message, "error: command requires at least 1 argument, got 0")
         


### PR DESCRIPTION
The error message received when running a command that expects only a required collected parameter is somewhat unintuitive:

```
error: command requires at least 0 arguments, got 0
```

There was also no test to explicitly check for this case using `ReqCollectedCmd`.