### PR TITLE
Indent newlines in help generator

### DIFF
--- a/Sources/SwiftCLI/HelpMessageGenerator.swift
+++ b/Sources/SwiftCLI/HelpMessageGenerator.swift
@@ -40,7 +40,9 @@ extension HelpMessageGenerator {
         
         func write(_ routable: Routable) {
             let spacing = String(repeating: " ", count: maxNameLength + 4 - routable.name.count)
-            out <<< "  \(routable.name)\(spacing)\(routable.shortDescription)"
+            let multilineSpacing = String(repeating: " ", count: maxNameLength + 4 + 2)
+            let description = routable.shortDescription.replacingOccurrences(of: "\n", with: "\n\(multilineSpacing)")
+            out <<< "  \(routable.name)\(spacing)\(description)"
         }
         
         if !commandGroups.isEmpty {
@@ -76,7 +78,7 @@ extension HelpMessageGenerator {
             }
             for option in sortedOptions {
                 let usage = option.usage(padding: maxOptionLength + 4)
-                out <<< "  \(usage)"
+                out <<< "  \(usage)".replacingOccurrences(of: "\n", with: "\n  ")
             }
         }
         out <<< ""

--- a/Sources/SwiftCLI/Option.swift
+++ b/Sources/SwiftCLI/Option.swift
@@ -15,7 +15,9 @@ public protocol Option {
 public extension Option {
     func usage(padding: Int) -> String {
         let spacing = String(repeating: " ", count: padding - identifier.count)
-        return "\(identifier)\(spacing)\(shortDescription)"
+        let descriptionNewlineSpacing = String(repeating: " ", count: padding)
+        let description = shortDescription.replacingOccurrences(of: "\n", with: "\n\(descriptionNewlineSpacing)")
+        return "\(identifier)\(spacing)\(description)"
     }
 }
 

--- a/Tests/SwiftCLITests/Fixtures.swift
+++ b/Tests/SwiftCLITests/Fixtures.swift
@@ -39,6 +39,20 @@ class TestCommand: Command {
 
 }
 
+class MultilineCommand: Command {
+
+    let name = "test"
+    let shortDescription = "A command that has multiline comments.\nNew line"
+
+    let silent = Flag("-s", "--silent", description: "Silence all test output\nNewline")
+    let times = Key<Int>("-t", "--times", description: "Number of times to run the test")
+
+    func execute() throws {
+
+    }
+
+}
+
 class TestInheritedCommand: TestCommand {
     let verbose = Flag("-v", "--verbose", description: "Show more output information")
 }

--- a/Tests/SwiftCLITests/HelpMessageGeneratorTests.swift
+++ b/Tests/SwiftCLITests/HelpMessageGeneratorTests.swift
@@ -140,4 +140,48 @@ class HelpMessageGeneratorTests: XCTestCase {
         """)
     }
 
+    func testMutlineUsageStatementGeneration() {
+        let pipe = PipeStream()
+        let command = MultilineCommand()
+        let cli = CLI.createTester(commands: [command])
+        let path = CommandGroupPath(top: cli).appending(command)
+        DefaultHelpMessageGenerator().writeUsageStatement(for: path, to: pipe)
+        pipe.closeWrite()
+
+        XCTAssertEqual(pipe.readAll(), """
+
+        Usage: tester test [options]
+
+        Options:
+          -h, --help             Show help information for this command
+          -s, --silent           Silence all test output
+                                 Newline
+          -t, --times <value>    Number of times to run the test
+
+
+        """)
+    }
+
+    func testMutlineCommandListGeneration() {
+        let pipe = PipeStream()
+        let path = CommandGroupPath(top: CLI.createTester(commands: [MultilineCommand(), betaCmd], description: "A tester for SwiftCLI"))
+        DefaultHelpMessageGenerator().writeCommandList(for: path, to: pipe)
+        pipe.closeWrite()
+
+        XCTAssertEqual(pipe.readAll(), """
+
+        Usage: tester <command> [options]
+
+        A tester for SwiftCLI
+
+        Commands:
+          test            A command that has multiline comments.
+                          New line
+          beta            A beta command
+          help            Prints this help information
+
+
+        """)
+    }
+
 }


### PR DESCRIPTION
This fixes the help generator output when a command or option has a multi-line description, by indenting it