### PR TITLE
Extend ConvertibleFromString

### DIFF
--- a/Sources/SwiftCLI/Option.swift
+++ b/Sources/SwiftCLI/Option.swift
@@ -129,30 +129,16 @@ public class VariadicKey<T: ConvertibleFromString>: AnyKey {
 
 // MARK: - ConvertibleFromString
 
+/// A type that can be created from a string
 public protocol ConvertibleFromString {
-    static func convert(from: String) -> Self?
+  /// Returns an instance of the conforming type from a string representation
+  static func convert(from: String) -> Self?
 }
 
 extension ConvertibleFromString where Self: LosslessStringConvertible {
   public static func convert(from: String) -> Self? {
     return Self(from)
   }
-}
-
-extension String: ConvertibleFromString {}
-extension Int: ConvertibleFromString {}
-extension Float: ConvertibleFromString {}
-extension Double: ConvertibleFromString {}
-
-extension Bool: ConvertibleFromString {
-    public static func convert(from: String) -> Bool? {
-        let lowercased = from.lowercased()
-        
-        if ["y", "yes", "t", "true"].contains(lowercased) { return true }
-        if ["n", "no", "f", "false"].contains(lowercased) { return false }
-        
-        return nil
-    }
 }
 
 extension ConvertibleFromString where Self: RawRepresentable, Self.RawValue: ConvertibleFromString {
@@ -162,4 +148,30 @@ extension ConvertibleFromString where Self: RawRepresentable, Self.RawValue: Con
     }
     return Self.init(rawValue: val)
   }
+}
+
+extension String: ConvertibleFromString {}
+extension Int: ConvertibleFromString {}
+extension Float: ConvertibleFromString {}
+extension Double: ConvertibleFromString {}
+
+extension Bool: ConvertibleFromString {
+  /// Returns a bool from a string representation
+  ///
+  /// - parameter from: A string representation of a bool value
+  ///
+  /// This is case insensitive and recognizes several representations:
+  ///
+  /// - true/false
+  /// - t/f
+  /// - yes/no
+  /// - y/n
+  public static func convert(from: String) -> Bool? {
+        let lowercased = from.lowercased()
+        
+        if ["y", "yes", "t", "true"].contains(lowercased) { return true }
+        if ["n", "no", "f", "false"].contains(lowercased) { return false }
+        
+        return nil
+    }
 }

--- a/Sources/SwiftCLI/Option.swift
+++ b/Sources/SwiftCLI/Option.swift
@@ -133,29 +133,16 @@ public protocol ConvertibleFromString {
     static func convert(from: String) -> Self?
 }
 
-extension String: ConvertibleFromString {
-    public static func convert(from: String) -> String? {
-        return from
-    }
+extension ConvertibleFromString where Self: LosslessStringConvertible {
+  public static func convert(from: String) -> Self? {
+    return Self(from)
+  }
 }
 
-extension Int: ConvertibleFromString {
-    public static func convert(from: String) -> Int? {
-        return Int(from)
-    }
-}
-
-extension Float: ConvertibleFromString {
-    public static func convert(from: String) -> Float? {
-        return Float(from)
-    }
-}
-
-extension Double: ConvertibleFromString {
-    public static func convert(from: String) -> Double? {
-        return Double(from)
-    }
-}
+extension String: ConvertibleFromString {}
+extension Int: ConvertibleFromString {}
+extension Float: ConvertibleFromString {}
+extension Double: ConvertibleFromString {}
 
 extension Bool: ConvertibleFromString {
     public static func convert(from: String) -> Bool? {
@@ -168,11 +155,11 @@ extension Bool: ConvertibleFromString {
     }
 }
 
-extension RawRepresentable where RawValue: ConvertibleFromString {
-    public static func convert(from: String) -> Self? {
-        guard let val = RawValue.convert(from: from) else {
-            return nil
-        }
-        return Self.init(rawValue: val)
+extension ConvertibleFromString where Self: RawRepresentable, Self.RawValue: ConvertibleFromString {
+  public static func convert(from: String) -> Self? {
+    guard let val = RawValue.convert(from: from) else {
+      return nil
     }
+    return Self.init(rawValue: val)
+  }
 }


### PR DESCRIPTION
I have added a default implementation to ConvertibleFromString for types that adopt the LosslessStringConvertible protocol. Maybe this can be nice to have in place, because types that conform to LosslessStringConvertible can also adopt ConvertibleFromString with less boilerplate. This is the case with Int, String, Float, and Double, where I removed the implementations, because the more generic but equivalent one can be used here. The Bool extension is kept, because the implementation here differs from that which is provided with the LosslessStringConvertible conformance. Many of my types already adopt LosslessStringConvertible and I would be happy to see this merged.