### PR TITLE
Add support for validation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,11 @@ let package = Package(
     name: "SwiftCLI",
     products: [
         .library(name: "SwiftCLI", targets: ["SwiftCLI"]),
+        .executable(name: "ExampleCLI", targets: ["ExampleCLI"])
     ],
     targets: [
         .target(name: "SwiftCLI", dependencies: []),
+        .target(name: "ExampleCLI", dependencies: ["SwiftCLI"]),
         .testTarget(name: "SwiftCLITests", dependencies: ["SwiftCLI"]),
     ]
 )

--- a/Sources/ExampleCLI/Car.swift
+++ b/Sources/ExampleCLI/Car.swift
@@ -1,0 +1,23 @@
+import SwiftCLI
+
+enum Car: String, Validatable, ConvertibleFromString {
+  case volvo, volkswagen, bmw, ferrari
+
+  public enum ValidationOption: Validatorable {
+    case isFast
+    case isSwedish
+
+    public func validate(element: Car) -> ValidationResult {
+      switch (self, element) {
+      case (.isFast, .ferrari):
+        return .succeeded
+      case (.isFast, _):
+        return .failed("\(element) is not fast")
+      case (.isSwedish, .volvo):
+        return .succeeded
+      case (.isSwedish, _):
+        return .failed("\(element) is not Swedish")
+      }
+    }
+  }
+}

--- a/Sources/ExampleCLI/main.swift
+++ b/Sources/ExampleCLI/main.swift
@@ -1,0 +1,47 @@
+import SwiftCLI
+
+class ExampleCommand: Command {
+  let name = "example"
+
+  let fastCar = Key<Car>("--fast-car",
+    description: "A fast car",
+    validation: [.isFast]
+  )
+
+  let swedishCar = Key<Car>("--swedish-car",
+    description: "A Swedish car",
+    validation: [.isSwedish]
+  )
+
+  let age = Key<Int>("--age",
+    description: "Your age",
+    validation: [.within(18...95)]
+  )
+
+  let person = Key<String>("--person",
+    description: "Your name",
+    validation: [.contains("Sir"), .min(7)]
+  )
+
+  func execute() throws {
+    if let car = swedishCar.value {
+      print("Got a swedish car:", car)
+    }
+
+    if let car = fastCar.value {
+      print("Got a fast car:", car)
+    }
+
+    if let age = age.value {
+      print("Got age:", age)
+    }
+
+    if let person = person.value {
+      print("Got name:", person)
+    }
+  }
+}
+
+CLI(name: "Example", commands: [
+  ExampleCommand(),
+]).goAndExit()

--- a/Sources/SwiftCLI/DefaultValidation.swift
+++ b/Sources/SwiftCLI/DefaultValidation.swift
@@ -1,0 +1,7 @@
+// Default validations for types extending ConvertibleFromString
+
+public enum DefaultValidation<T>: Validatorable {
+  public func validate(element: T) -> ValidationResult {
+    return .succeeded
+  }
+}

--- a/Sources/SwiftCLI/Error.swift
+++ b/Sources/SwiftCLI/Error.swift
@@ -11,16 +11,16 @@ public protocol ProcessError: Swift.Error {
 }
 
 extension CLI {
-    
+
     public struct Error: ProcessError {
-        
+
         public let message: String?
         public let exitStatus: Int32
-        
+
         public init() {
             self.init(exitStatus: 1)
         }
-        
+
         #if swift(>=4.0)
         public init<T: BinaryInteger>(exitStatus: T) {
             self.init(message: nil, exitStatus: Int32(exitStatus))
@@ -37,14 +37,14 @@ extension CLI {
         public init(message: String) {
             self.init(message: message, exitStatus: 1)
         }
-        
+
         public init(message: String?, exitStatus: Int32) {
             self.message = message
             self.exitStatus = exitStatus
         }
-        
+
     }
-    
+
 }
 
 // MARK: - Parse errors
@@ -52,7 +52,7 @@ extension CLI {
 public struct RouteError: Swift.Error {
     public let partialPath: CommandGroupPath
     public let notFound: String?
-    
+
     public init(partialPath: CommandGroupPath, notFound: String?) {
         self.partialPath = partialPath
         self.notFound = notFound
@@ -60,13 +60,14 @@ public struct RouteError: Swift.Error {
 }
 
 public struct OptionError: Swift.Error {
-    
+
     public enum Kind {
         case expectedValueAfterKey(String)
         case illegalTypeForKey(String, Any.Type)
         case unrecognizedOption(String)
         case optionGroupMisuse(OptionGroup)
-        
+        case validationError(String, String)
+
         public var message: String {
             switch self {
             case let .expectedValueAfterKey(key):
@@ -75,6 +76,8 @@ public struct OptionError: Swift.Error {
                 return "illegal value passed to '\(key)' (expected \(type))"
             case let .unrecognizedOption(opt):
                 return "unrecognized option '\(opt)'"
+            case let .validationError(opt, message):
+                return "\(message): for option '\(opt)'"
             case let .optionGroupMisuse(group):
                 let condition: String
                 if group.options.count == 1 {
@@ -93,10 +96,10 @@ public struct OptionError: Swift.Error {
             }
         }
     }
-    
+
     public let command: CommandPath?
     public let kind: Kind
-    
+
     public init(command: CommandPath?, kind: Kind) {
         self.command = command
         self.kind = kind
@@ -104,14 +107,14 @@ public struct OptionError: Swift.Error {
 }
 
 public struct ParameterError: Swift.Error {
-    
+
     public let command: CommandPath
     public let minCount: Int
     public let maxCount: Int?
-    
+
     public var message: String {
         let plural = minCount == 1 ? "argument" : "arguments"
-        
+
         switch maxCount {
         case .none:
             return "command requires at least \(minCount) \(plural)"
@@ -121,7 +124,7 @@ public struct ParameterError: Swift.Error {
             return "command requires between \(minCount) and \(max) arguments"
         }
     }
-    
+
     public init(command: CommandPath, paramIterator: ParameterIterator) {
         self.command = command
         self.minCount = paramIterator.minCount

--- a/Sources/SwiftCLI/Protocols/ConvertibleFromString.swift
+++ b/Sources/SwiftCLI/Protocols/ConvertibleFromString.swift
@@ -1,0 +1,10 @@
+// MARK: - ConvertibleFromString
+
+/// A type that can be created from a string
+
+public protocol ConvertibleFromString {
+  /// Returns an instance of the conforming type from a string representation
+  associatedtype ValidationOption: Validatorable = DefaultValidation<Self>
+
+  static func convert(from: String) -> Self?
+}

--- a/Sources/SwiftCLI/Protocols/Validatable.swift
+++ b/Sources/SwiftCLI/Protocols/Validatable.swift
@@ -1,0 +1,4 @@
+public protocol Validatable {
+    associatedtype ValidationOption: Validatorable
+        where ValidationOption.Element == Self
+}

--- a/Sources/SwiftCLI/Protocols/Validatorable.swift
+++ b/Sources/SwiftCLI/Protocols/Validatorable.swift
@@ -1,0 +1,4 @@
+public protocol Validatorable {
+    associatedtype Element
+    func validate(element: Element) -> ValidationResult
+}

--- a/Sources/SwiftCLI/UpdateResult.swift
+++ b/Sources/SwiftCLI/UpdateResult.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum UpdateResult: Equatable {
+    case succeeded
+    case illegalType
+    case validationError(String)
+
+    public static func == (lhs: UpdateResult, rhs: UpdateResult) -> Bool {
+        switch (lhs, rhs) {
+        case (.succeeded, .succeeded):
+            return true
+        case (.illegalType, .illegalType):
+            return true
+        case let (.validationError(msg1), .validationError(msg2)):
+            return msg1 == msg2
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/SwiftCLI/ValidationResult.swift
+++ b/Sources/SwiftCLI/ValidationResult.swift
@@ -1,0 +1,4 @@
+public enum ValidationResult {
+  case succeeded
+  case failed(String)
+}

--- a/Sources/SwiftCLI/Validations/Double.swift
+++ b/Sources/SwiftCLI/Validations/Double.swift
@@ -1,0 +1,5 @@
+extension Double: ConvertibleFromString {}
+
+extension Double: Validatable {
+  public typealias ValidationOption = NumericValidationOption<Double>
+}

--- a/Sources/SwiftCLI/Validations/Float.swift
+++ b/Sources/SwiftCLI/Validations/Float.swift
@@ -1,0 +1,5 @@
+extension Float: ConvertibleFromString {}
+
+extension Float: Validatable {
+  public typealias ValidationOption = NumericValidationOption<Float>
+}

--- a/Sources/SwiftCLI/Validations/Int.swift
+++ b/Sources/SwiftCLI/Validations/Int.swift
@@ -1,0 +1,5 @@
+extension Int: ConvertibleFromString {}
+
+extension Int: Validatable {
+  public typealias ValidationOption = NumericValidationOption<Int>
+}

--- a/Sources/SwiftCLI/Validations/Numeric.swift
+++ b/Sources/SwiftCLI/Validations/Numeric.swift
@@ -1,0 +1,21 @@
+public enum NumericValidationOption<T: Numeric & Comparable>: Validatorable {
+  case min(T)
+  case max(T)
+  case within(ClosedRange<T>)
+  case positive
+
+  public func validate(element: T) -> ValidationResult {
+      switch self {
+      case .positive where element <= 0:
+         return .failed("Cannot be less then zero")
+      case let .min(value) where value > element:
+        return .failed("Must be larger then \(value)")
+      case let .max(value) where value < element:
+        return .failed("Must be smaller then \(value)")
+      case let .within(range) where !range.contains(element):
+        return .failed("Must be between \(range.lowerBound) and \(range.upperBound)")
+      default:
+        return .succeeded
+      }
+  }
+}

--- a/Sources/SwiftCLI/Validations/String.swift
+++ b/Sources/SwiftCLI/Validations/String.swift
@@ -1,0 +1,19 @@
+extension String: ConvertibleFromString {}
+
+extension String: Validatable {
+  public enum ValidationOption: Validatorable {
+    case min(Int)
+    case contains(String)
+
+    public func validate(element: String) -> ValidationResult {
+      switch self {
+      case let .min(value) where value > element.count:
+        return .failed("Must be larger then \(value)")
+      case let .contains(value) where !element.contains(value):
+        return .failed("Does not contain '\(value)'")
+      default:
+        return .succeeded
+      }
+    }
+  }
+}

--- a/Tests/SwiftCLITests/ValidationEnumTests.swift
+++ b/Tests/SwiftCLITests/ValidationEnumTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import SwiftCLI
+
+enum Car: String, Validatable, ConvertibleFromString {
+    case volvo, volkswagen, bmw, ferrari
+
+    public enum ValidationOption: Validatorable {
+        case isFast
+
+        public func validate(element: Car) -> ValidationResult {
+            switch (self, element) {
+            case (.isFast, .ferrari):
+                return .succeeded
+            default:
+                return .failed("Is not fast")
+            }
+        }
+    }
+}
+
+class ValidationEnumTests: XCTestCase {
+    static var allTests : [(String, (ValidationEnumTests) -> () -> Void)] {
+        return [
+            ("testEnumValidation", testEnumValidation)
+        ]
+    }
+
+    func testEnumValidation() {
+        let car = Key<Car>("--car",
+          description: "A car",
+          validation: [.isFast]
+        )
+
+        XCTAssertEqual(
+            car.updateValue("volvo"),
+            .validationError("Is not fast"),
+            "Should fail on slow car"
+        )
+
+        XCTAssertEqual(
+            car.updateValue("ferrari"),
+            .succeeded,
+            "Should succeed on fast car"
+        )
+    }
+}

--- a/Tests/SwiftCLITests/ValidationNumericTests.swift
+++ b/Tests/SwiftCLITests/ValidationNumericTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import SwiftCLI
+
+class ValidationNumericTests: XCTestCase {
+    static var allTests : [(String, (ValidationNumericTests) -> () -> Void)] {
+        return [
+            ("testIntMinValidation", testIntMinValidation),
+            ("testFloatMinValidation", testFloatMinValidation),
+            ("testIntMaxValidation", testIntMaxValidation),
+            ("testFloatMaxValidation", testFloatMaxValidation),
+            ("testIntWithinValidation", testIntWithinValidation),
+            ("testFloatWithinValidation", testFloatWithinValidation)
+        ]
+    }
+
+    func testIntMinValidation() {
+        let key = Key<Int>("--key",
+            description: "A key",
+            validation: [.min(5)]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("3"),
+            .validationError("Must be larger then 5"),
+            "Should validate min value and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("7"),
+            .succeeded,
+            "Should validate min value and succeed"
+        )
+
+    }
+
+    func testIntMaxValidation() {
+        let key = Key<Int>("--key",
+            description: "A key",
+            validation: [.max(5)]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("10"),
+            .validationError("Must be smaller then 5"),
+            "Should validate max value and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("3"),
+            .succeeded,
+            "Should validate max value and succeed"
+        )
+
+    }
+
+    func testFloatMinValidation() {
+        let key = Key<Float>("--key",
+            description: "A key",
+            validation: [.min(5.0)]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("3"),
+            .validationError("Must be larger then 5.0"),
+            "Should validate min value and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("7.0"),
+            .succeeded,
+            "Should validate min value and succeed"
+        )
+
+    }
+
+    func testFloatMaxValidation() {
+        let key = Key<Float>("--key",
+            description: "A key",
+            validation: [.max(5.0)]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("7.0"),
+            .validationError("Must be smaller then 5.0"),
+            "Should validate max value and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("2.0"),
+            .succeeded,
+            "Should validate max value and succeed"
+        )
+
+    }
+
+    func testIntWithinValidation() {
+        let key = Key<Int>("--key",
+            description: "A key",
+            validation: [.within(5...8)]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("3"),
+            .validationError("Must be between 5 and 8"),
+            "Should validate int outside (low) range and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("9"),
+            .validationError("Must be between 5 and 8"),
+            "Should validate int outside (over) range and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("5"),
+            .succeeded,
+            "Should succeed if at lower bound"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("8"),
+            .succeeded,
+            "Should succeed if at upper bound"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("7"),
+            .succeeded,
+            "Should validate in middle of range"
+        )
+    }
+
+    func testFloatWithinValidation() {
+        let key = Key<Float>("--key",
+            description: "A key",
+            validation: [.within(5.0...8.0)]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("3.0"),
+            .validationError("Must be between 5.0 and 8.0"),
+            "Should validate float outside (low) range and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("9.0"),
+            .validationError("Must be between 5.0 and 8.0"),
+            "Should validate float outside (over) range and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("5.0"),
+            .succeeded,
+            "Should succeed if at lower bound"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("8.0"),
+            .succeeded,
+            "Should succeed if at upper bound"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("7.0"),
+            .succeeded,
+            "Should validate in middle of range"
+        )
+    }
+}

--- a/Tests/SwiftCLITests/ValidationStringTests.swift
+++ b/Tests/SwiftCLITests/ValidationStringTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import SwiftCLI
+
+class ValidationStringTests: XCTestCase {
+    static var allTests : [(String, (ValidationStringTests) -> () -> Void)] {
+        return [
+            ("testStringMinValidation", testStringMinValidation),
+            ("testStringContainValidation", testStringContainValidation)
+        ]
+    }
+
+    func testStringMinValidation() {
+        let key = Key<String>("--key",
+            description: "A key",
+            validation: [.min(5)]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("A"),
+            .validationError("Must be larger then 5"),
+            "Should validate min length and fail"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("ABCDEF"),
+            .succeeded,
+            "Should validate min length and succeeded"
+        )
+    }
+
+    func testStringContainValidation() {
+        let key = Key<String>("--key",
+            description: "A key",
+            validation: [.contains("ABC")]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("DEF"),
+            .validationError("Does not contain 'ABC'"),
+            "Should validate substring"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("ABCDEF"),
+            .succeeded,
+            "Should validate sub string and succeed"
+        )
+    }
+
+    func testStringMultiplyValidation() {
+        let key = Key<String>("--key",
+            description: "A key",
+            validation: [.min(4), .contains("ABC")]
+        )
+
+        XCTAssertEqual(
+            key.updateValue("ABCD"),
+            .succeeded,
+            "Should validate min length and sub string"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("ABC"),
+            .validationError("Must be larger then 4"),
+            "Should validate length"
+        )
+
+        XCTAssertEqual(
+            key.updateValue("DEFG"),
+            .validationError("Does not contain 'ABC'"),
+            "Should check for substring"
+        )
+    }
+}


### PR DESCRIPTION
I've tried to come up with a generic solution for validating user input. Found what I think is a clean, compact DSL that takes advantage of Swift type system. Have been using it locally for a few months so thought I would share it.

Here's an example that makes sure the key `--age` is between 18 and 95.

``` swift
let age = Key<Int>("--age",
  description: "Your age",
  validation: [.within(18...95)]
)
```

The validation `.within(18...95)` is bound to the `Int` type. Validations can be used on all types implementing the `Validatorable` protocol.

Here's a simplified extension for the `String` type adding support for `.min` and `.contains`.

``` swift
extension String: Validatable {
  public enum ValidationOption: Validatorable {
    case contains(String)
    case min(Int)

    public func validate(element: String) -> ValidationResult {
      switch self {
      case let .min(length) where element.count < length:
          return .failed("Length is smaller then \(length)")
      case let .contains(value) where !element.contains(value):
        return .failed("Does not contain '\(value)'")
      default:
        return .succeeded
      }
    }
  }
}
```

The `ValidationResult` type is an enum of either `.succeeded` or `.failed(String)`. The user can now use `.min` and `.contains` like:

``` swift
let person = Key<String>("--person",
  description: "A persons name",
  validation: [.min(3), .contains("a")]
)

// --person abcd # OK
// --person ab # Length is smaller then 3
// --person defg # Does not contain 'a'
```

This also works with enums.

``` swift
enum Car: String, Validatable, ConvertibleFromString {
  case volvo, volkswagen, bmw, ferrari

  public enum ValidationOption: Validatorable {
    case isFast
    case isSwedish

    public func validate(element: Car) -> ValidationResult {
      switch (self, element) {
      case (.isFast, .ferrari):
        return .succeeded
      case (.isFast, _):
        return .failed("\(element) is not fast")
      case (.isSwedish, .volvo):
        return .succeeded
      case (.isSwedish, _):
        return .failed("\(element) is not Swedish")
      }
    }
  }
}

let car = Key<Car>("--car",
  description: "A car",
  validation: [.isFast]
)

// --car ferrari // OK
// --car volvo // Volvo is not fast
```

As a starting point I've included validations for the numeric types `Double`, `Float` and `Int` as well as a few basic ones for the string class, `String`.

I've also included a few examples in `Sources/ExampleCLI/main.swift`. You can execute them by running `swift build && ./.build/x86_64-apple-macosx10.10/debug/ExampleCLI example`.

I've tried to keep this pull request as simple as possible. The current validations are just there to give an idea of what can be done. I'm happy to add more if this type of a DSL is interesting for the project. 

I've also experimented with the features below. They are not included in this PR but I'm happy to add them if you find them interesting.

### Blacklist values

``` swift
let name = Key<String>("--name",
  description: "Your name",
  reject: ["Mussolini"]
)

// --name Mussolini # Mussolini is not allowed for --name
// --name John # OK
```

### Whitelist values

``` swift
let dog = Key<String>("--dog",
  description: "Name of your dog",
  allowed: ["Tim", "John"]
)

// --dog Flisa # Only Tim and John allowed for --dog
// --dog Tim # OK
```

### Array values separated by commas

``` swift
enum Family: String, ConvertibleFromString {
  case sister, dad, mother
}

let family = Key<Family>("--family",
  description: "Family members"
)

// --family dad,mother
family.value == [.dad, .mother]
```

### Examples for `--help`

``` swift
let animal = Key<String>("--animal",
  description: "An animal",
  examples: ["horse", "monkey"]
)

// --help yields: Examples: horse, monkey
```

### Default values

When no value is passed, use the `default` param.
`default` is also displayed when running `--help`.

``` swift
enum Bike: String, ConvertibleFromString {
  case specialized, giant
}

let bike = Key<Bike>("--bike",
  description: "A bike",
  default: .giant
)
```

### List enums

Display all possible cases for an enum using [allCases](https://developer.apple.com/documentation/swift/caseiterable/2994869-allcases) in Swift 4.2.

``` swift
enum Animal: String, ConvertibleFromString, CaseIterable {
  case horse, dog, snake
}

let animal = Key<Animal>("--animal",
  description: "An animal"
)

// --help displays: Possible values: horse, dog, snake
```

If you find this interesting I'm happy to provide more pull requests with support for the above.

I've also added the appropriate test cases to verify the implementation in `Tests/SwiftCLITests`.

I'm flexible when it comes to naming conventions so if you have any better names for protocols, functions or variabels, I'm all ears :)
