### PR TITLE
Removed invalid override keyword (Swift 5.1)

### DIFF
--- a/Sources/SwiftCLI/Option.swift
+++ b/Sources/SwiftCLI/Option.swift
@@ -124,7 +124,7 @@ public class Key<Value: ConvertibleFromString>: _Key<Value>, AnyKey, ValueBox {
     
     public var value: Value?
     
-    public override init(_ names: String ..., description: String = "", completion: ShellCompletion = .filename, validation: [Validation<Value>] = []) {
+    public init(_ names: String ..., description: String = "", completion: ShellCompletion = .filename, validation: [Validation<Value>] = []) {
         super.init(names, description: description, completion: completion, validation: validation)
     }
     
@@ -138,7 +138,7 @@ public class VariadicKey<Value: ConvertibleFromString>: _Key<Value>, AnyKey, Val
     
     public var value: [Value] = []
     
-    public override init(_ names: String ..., description: String = "", completion: ShellCompletion = .filename, validation: [Validation<Value>] = []) {
+    public init(_ names: String ..., description: String = "", completion: ShellCompletion = .filename, validation: [Validation<Value>] = []) {
         super.init(names, description: description, completion: completion, validation: validation)
     }
     

--- a/Sources/SwiftCLI/Option.swift
+++ b/Sources/SwiftCLI/Option.swift
@@ -111,7 +111,7 @@ public class _Key<Value: ConvertibleFromString> {
     /// - Parameters:
     ///   - names: the names for the key; convention is to include a short name (-m) and a long name (--message)
     ///   - description: A short description of what this key does for usage statements
-    public init(_ names: [String], description: String, completion: ShellCompletion, validation: [Validation<Value>] = []) {
+    public init(names: [String], description: String, completion: ShellCompletion, validation: [Validation<Value>] = []) {
         self.names = names
         self.shortDescription = description
         self.completion = completion
@@ -125,7 +125,7 @@ public class Key<Value: ConvertibleFromString>: _Key<Value>, AnyKey, ValueBox {
     public var value: Value?
     
     public init(_ names: String ..., description: String = "", completion: ShellCompletion = .filename, validation: [Validation<Value>] = []) {
-        super.init(names, description: description, completion: completion, validation: validation)
+        super.init(names: names, description: description, completion: completion, validation: validation)
     }
     
     public func update(to value: Value) {
@@ -139,7 +139,7 @@ public class VariadicKey<Value: ConvertibleFromString>: _Key<Value>, AnyKey, Val
     public var value: [Value] = []
     
     public init(_ names: String ..., description: String = "", completion: ShellCompletion = .filename, validation: [Validation<Value>] = []) {
-        super.init(names, description: description, completion: completion, validation: validation)
+        super.init(names: names, description: description, completion: completion, validation: validation)
     }
     
     public func update(to value: Value) {


### PR DESCRIPTION
Hi @jakeheis, I just tried to install SwiftCLI via the SPM integration in Xcode 11 beta 2 with Swift 5.1 and I couldn't build my target because of an error with invalid usage of the `override` keyword. I removed it and tried compiling it with both Swift 5.1 & Swift 4.2 which worked fine.