### PR TITLE
Make input publicly configurable

### DIFF
--- a/Sources/SwiftCLI/Input.swift
+++ b/Sources/SwiftCLI/Input.swift
@@ -103,7 +103,7 @@ public class InputReader<T: ConvertibleFromString> {
                     possibleInput = String(cString: chars, encoding: .utf8)
                 }
             } else {
-                possibleInput = ReadInput.read()
+                possibleInput = Term.read()
             }
             
             guard let input = possibleInput else {
@@ -135,17 +135,4 @@ public class InputReader<T: ConvertibleFromString> {
         }
     }
     
-}
-
-// MARK: - ReadInput
-
-/// Internal struct which enables testing of Input
-struct ReadInput {
-    static var read: () -> String? = normalRead
-    
-    static func normalRead() -> String? {
-        return readLine()
-    }
-    
-    private init() {}
 }

--- a/Sources/SwiftCLI/Term.swift
+++ b/Sources/SwiftCLI/Term.swift
@@ -14,5 +14,6 @@ public enum Term {
     public static var stdout: WritableStream = WriteStream.stdout
     public static var stderr: WritableStream = WriteStream.stderr
     public static var stdin: ReadableStream = ReadStream.stdin
+    public static var read: () -> String? = { readLine() }
 
 }

--- a/Tests/SwiftCLITests/InputTests.swift
+++ b/Tests/SwiftCLITests/InputTests.swift
@@ -15,7 +15,7 @@ class InputTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ReadInput.read = {
+        Term.read = {
             return self.input.removeFirst()
         }
     }


### PR DESCRIPTION
This makes it possible to publicly edit the `readLine()` that `InputReader` uses. It also moves `read()` from `Input` to `Term`