### PR TITLE
Add support for redirecting captured output as it's being written

### DIFF
--- a/Sources/SwiftCLI/Stream.swift
+++ b/Sources/SwiftCLI/Stream.swift
@@ -455,7 +455,9 @@ public class CaptureStream: ProcessingStream {
     private var waited = false
     
     /// Creates a new stream which collects all data written to it
-    public init() {
+    ///
+    /// - Parameter each: called every time a chunk of data is written to the stream
+    public init(each: ((Data) -> ())? = nil) {
         let pipe = Pipe()
         self.processObject = pipe
         self.writeHandle = pipe.fileHandleForWriting
@@ -464,6 +466,7 @@ public class CaptureStream: ProcessingStream {
         queue.async { [weak self] in
             while let chunk = readStream.readData() {
                 self?.content += chunk
+                each?(chunk)
             }
             self?.semaphore.signal()
         }

--- a/Sources/SwiftCLI/Stream.swift
+++ b/Sources/SwiftCLI/Stream.swift
@@ -494,7 +494,7 @@ public class CaptureStream: ProcessingStream {
     
 }
 
-public class SplitStream: WritableStream {
+public class SplitStream: ProcessingStream {
 
     public let writeHandle: FileHandle
     public let processObject: Any
@@ -524,6 +524,11 @@ public class SplitStream: WritableStream {
 
     public convenience init(_ streams: WritableStream...) {
         self.init(streams: streams)
+    }
+
+     public func waitToFinishProcessing() {
+         semaphore.wait()
+         streams.forEach { ($0 as? ProcessingStream)?.waitToFinishProcessing() }
     }
 
 }

--- a/Sources/SwiftCLI/Task.swift
+++ b/Sources/SwiftCLI/Task.swift
@@ -222,13 +222,17 @@ extension Task {
     ///   - executable: the executable to run
     ///   - arguments: arguments to pass to the executable
     ///   - directory: the directory to run in; default current directory
+    ///   - forwardInterrupt: Whether interrupt signals which this process receives should be forwarded to this task; defaults to true
+    ///   - env: Environment in which to execute the task; defaults to same as this process
     /// - Returns: the captured data
     /// - Throws: CaptureError if command fails
-    public static func capture(_ executable: String, arguments: [String], directory: String? = nil) throws -> CaptureResult {
+    public static func capture(_ executable: String, arguments: [String], directory: String? = nil, forwardInterrupt: Bool = true, env: [String: String] = ProcessInfo.processInfo.environment) throws -> CaptureResult {
         let out = CaptureStream()
         let err = CaptureStream()
         
         let task = Task(executable: executable, arguments: arguments, directory: directory, stdout: out, stderr: err)
+        task.env = env
+        task.forwardInterrupt = forwardInterrupt
         let exitCode = task.runSync()
         
         let captured = CaptureResult(stdoutData: out.readAllData(), stderrData: err.readAllData())


### PR DESCRIPTION
This allows printing or redirecting output as it's being captured, analogous to the `tee` command. For example:

```sh
NSUnbufferedIO=YES softwareupdate --list | tee /dev/tty | grep -Fq $needle
```

Can be written as:

```swift
let result = try Task.capture(
    "softwareupdate",
    arguments: ["--list"],
    outputStream: Term.stdout,
    env: [
        "NSUnbufferedIO": "YES",
    ]
)

if result.output.contains(needle) { /* ... */ }
```

Currently to do this without a fork requires re-implementing `Task.capture`, `CaptureStream`, `CaptureResult`, and `CaptureError`.

I've also added support for passing in `forwardInterrupt` and `env` properties as arguments, can open a separate PR for that if necessary.

For `CaptureStream`, I used a block instead of another `WritableStream` parameter as that was more consistent with the surrounding code and similar to the [`readabilityHandler`](https://developer.apple.com/documentation/foundation/filehandle/1412413-readabilityhandler) block on `FileHandle`.