### PR TITLE
Add support for fallback values in input prompts

### DIFF
--- a/Sources/SwiftCLI/Input.swift
+++ b/Sources/SwiftCLI/Input.swift
@@ -32,7 +32,7 @@ public enum Input {
     ///   - errorResponse: what to do if the input is invalid; default prints "Invalid input"
     /// - Returns: input
     public static func readInt(prompt: String? = nil, defaultValue: Int? = nil, secure: Bool = false, validation: [Validation<Int>] = [], errorResponse: InputReader<Int>.ErrorResponse? = nil) -> Int {
-        return readObject(prompt: prompt, secure: secure, validation: validation, errorResponse: errorResponse)
+        return readObject(prompt: prompt, defaultValue: defaultValue, secure: secure, validation: validation, errorResponse: errorResponse)
     }
     
     /// Reads a double from stdin
@@ -45,7 +45,7 @@ public enum Input {
     ///   - errorResponse: what to do if the input is invalid; default prints "Invalid input"
     /// - Returns: input
     public static func readDouble(prompt: String? = nil, defaultValue: Double? = nil, secure: Bool = false, validation: [Validation<Double>] = [], errorResponse: InputReader<Double>.ErrorResponse? = nil) -> Double {
-        return readObject(prompt: prompt, secure: secure, validation: validation, errorResponse: errorResponse)
+        return readObject(prompt: prompt, defaultValue: defaultValue, secure: secure, validation: validation, errorResponse: errorResponse)
     }
     
     /// Reads a bool from stdin. "y", "yes", "t", and "true" are accepted as truthy values

--- a/Tests/SwiftCLITests/InputTests.swift
+++ b/Tests/SwiftCLITests/InputTests.swift
@@ -21,7 +21,7 @@ class InputTests: XCTestCase {
     }
     
     func testInt() {
-        input = ["asdf", "3.4", "5"]
+        input = ["", "asdf", "3.4", "5"]
         let (out, err) = CLI.capture {
             let int = Input.readInt()
             XCTAssertEqual(int, 5)
@@ -30,12 +30,13 @@ class InputTests: XCTestCase {
         XCTAssertEqual(err, """
         Invalid value; expected Int
         Invalid value; expected Int
+        Invalid value; expected Int
         
         """)
     }
     
     func testDouble() {
-        input = ["asdf", "3.4", "5"]
+        input = ["", "asdf", "3.4", "5"]
         let (out, err) = CLI.capture {
             let double = Input.readDouble()
             XCTAssertEqual(double, 3.4)
@@ -43,18 +44,20 @@ class InputTests: XCTestCase {
         XCTAssertEqual(out, "")
         XCTAssertEqual(err, """
         Invalid value; expected Double
+        Invalid value; expected Double
         
         """)
     }
     
     func testBool() {
-        input = ["asdf", "5", "false"]
+        input = ["", "asdf", "5", "false"]
         let (out, err) = CLI.capture {
             let bool = Input.readBool()
             XCTAssertEqual(bool, false)
         }
         XCTAssertEqual(out, "")
         XCTAssertEqual(err, """
+        Invalid value; expected Bool
         Invalid value; expected Bool
         Invalid value; expected Bool
 
@@ -84,9 +87,24 @@ class InputTests: XCTestCase {
 
         """)
     }
-    
+
+    func testDefaultValue() {
+        runTestCases(valid: [("5", 5), ("\n", 5)], invalid: ["invalid", "3.4"], expectedErrorOutput: "Invalid value; expected Int") {
+            Input.readInt(defaultValue: 5)
+        }
+        runTestCases(valid: [("3.4", 3.4), ("5", 5), ("", 3.4)], invalid: ["invalid"], expectedErrorOutput: "Invalid value; expected Double") {
+            Input.readDouble(defaultValue: 3.4)
+        }
+        runTestCases(valid: [("false", false), ("true", true), ("", false)], invalid: ["invalid", "3.4", "5"], expectedErrorOutput: "Invalid value; expected Bool") {
+            Input.readBool(defaultValue: false)
+        }
+        runTestCases(valid: [("false", false), ("true", true), ("", true)], invalid: ["invalid", "3.4", "5"], expectedErrorOutput: "Invalid value; expected Bool") {
+            Input.readBool(defaultValue: true)
+        }
+    }
+
     func testValidation() {
-        input = ["asdf", "3.4", "5", "9", "11"]
+        input = ["", "asdf", "3.4", "5", "9", "11"]
         let (out, err) = CLI.capture {
             let int = Input.readInt(validation: [.greaterThan(10)])
             XCTAssertEqual(int, 11)
@@ -95,12 +113,13 @@ class InputTests: XCTestCase {
         XCTAssertEqual(err, """
         Invalid value; expected Int
         Invalid value; expected Int
+        Invalid value; expected Int
         Invalid value; must be greater than 10
         Invalid value; must be greater than 10
 
         """)
         
-        input = ["asdf", "5", "false", "SwiftCLI"]
+        input = ["", "asdf", "5", "false", "SwiftCLI"]
         let (out2, err2) = CLI.capture {
             let str = Input.readLine(validation: [.contains("ift")])
             XCTAssertEqual(str, "SwiftCLI")
@@ -110,8 +129,30 @@ class InputTests: XCTestCase {
         Invalid value; must contain 'ift'
         Invalid value; must contain 'ift'
         Invalid value; must contain 'ift'
+        Invalid value; must contain 'ift'
 
         """)
     }
 
+    private func runTestCases<T: Equatable>(valid validCases: [(String, T)], invalid invalidCases: [String], expectedErrorOutput: String, block: () -> T) {
+        precondition(!validCases.isEmpty)
+
+        for (validCase, expectedValue) in validCases {
+            input = [validCase]
+            let (out, err) = CLI.capture {
+                XCTAssertEqual(block(), expectedValue)
+            }
+            XCTAssertEqual(out, "")
+            XCTAssertEqual(err, "")
+        }
+
+        // NOTE: Input needs to end in a valid entry so it completes.
+        input = invalidCases + [validCases[0].0]
+
+        let (out, err) = CLI.capture {
+            _ = block()
+        }
+        XCTAssertEqual(out, "")
+        XCTAssertEqual(err, String(repeating: expectedErrorOutput + "\n", count: invalidCases.count))
+    }
 }


### PR DESCRIPTION
This allows writing the following:

```swift
let proceed = Input.readBool(prompt: "Proceed? [Y/n]: ", defaultValue: true)
```

It falls back to `defaultValue` only for empty input. Invalid input is treated the same as it is already (i.e., it's refused until corrected, which matches the behavior of most CLIs).

Existing behavior is the same (no breaking changes).