### PR TITLE
Suppress deprecation warning

### DIFF
--- a/Sources/SwiftCLI/Command.swift
+++ b/Sources/SwiftCLI/Command.swift
@@ -8,7 +8,7 @@
 
 // MARK: - Routables
 
-public protocol Routable: class {
+public protocol Routable: AnyObject {
     /// The name of the command or command group
     var name: String { get }
     

--- a/Sources/SwiftCLI/Option.swift
+++ b/Sources/SwiftCLI/Option.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 jakeheis. All rights reserved.
 //
 
-public protocol Option: class, CustomStringConvertible {
+public protocol Option: AnyObject, CustomStringConvertible {
     var names: [String] { get }
     var shortDescription: String { get }
     var identifier: String { get }

--- a/Sources/SwiftCLI/Stream.swift
+++ b/Sources/SwiftCLI/Stream.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - WritableStream
 
-public protocol WritableStream: class {
+public protocol WritableStream: AnyObject {
     var writeHandle: FileHandle { get }
     var processObject: Any { get }
     var encoding: String.Encoding { get }
@@ -184,7 +184,7 @@ public enum WriteStream {
 
 // MARK: - Readable
 
-public protocol ReadableStream: class {
+public protocol ReadableStream: AnyObject {
     var readHandle: FileHandle { get }
     var processObject: Any { get }
     var encoding: String.Encoding { get }

--- a/Sources/SwiftCLI/ValueBox.swift
+++ b/Sources/SwiftCLI/ValueBox.swift
@@ -17,7 +17,7 @@ public enum InvalidValueReason {
 
 // MARK: -
 
-public protocol AnyValueBox: class {
+public protocol AnyValueBox: AnyObject {
     var completion: ShellCompletion { get }
     var valueType: ConvertibleFromString.Type { get }
     


### PR DESCRIPTION
## Description

On latest Swift compilers recommend using `: AnyObject` instead of `: class`.

So it raises deprecation warnings. This PR to suppress them.

### Before

```
$ swift build
[1/22] Compiling SwiftCLI ValueBox.swift
/Users/giginet/.ghq/github.com/jakeheis/SwiftCLI/Sources/SwiftCLI/ValueBox.swift:20:30: warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead
public protocol AnyValueBox: class {
                             ^~~~~
                             AnyObject
[2/22] Compiling SwiftCLI VersionCommand.swift
/Users/giginet/.ghq/github.com/jakeheis/SwiftCLI/Sources/SwiftCLI/ValueBox.swift:20:30: warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead
public protocol AnyValueBox: class {
                             ^~~~~
                             AnyObject
```