### PR TITLE
Fix strdup optional check

### DIFF
--- a/Sources/SwiftCLI/Task.swift
+++ b/Sources/SwiftCLI/Task.swift
@@ -283,7 +283,10 @@ extension Task {
         }
         
         let argv = ([exec] + swiftArgs).map({ $0.withCString(strdup) })
-        defer { argv.forEach { free($0)} }
+        defer {
+            argv.compactMap { $0 }
+                .forEach { free($0)}
+        }
         
         var priorDir: String? = nil
         if let directory = directory {
@@ -297,7 +300,9 @@ extension Task {
             envp[env.count] = nil
             defer {
                 for pair in envp ..< envp + env.count {
-                    free(UnsafeMutableRawPointer(pair.pointee))
+                    pair.pointee.map {
+                        free(UnsafeMutableRawPointer($0))
+                    }
                 }
                 #if swift(>=4.1)
                 envp.deallocate()


### PR DESCRIPTION
This fixes the build of SwiftCLI on Xcode 13 RC.

strdup returns an implicitly unwrapped optional which is breaking the build. The change is quite straightforward and it'd be great if we can merge and make a release as soon as possible.